### PR TITLE
Fix for evrythng.js work in Adobe Experience Manager (AEM)

### DIFF
--- a/dist/evrythng.js
+++ b/dist/evrythng.js
@@ -1883,7 +1883,9 @@ define('network/cors',[
         headers = headers.trim().split("\n");
         for (var h in headers) {
           var header = headers[h].match(/([^:]+):(.*)/);
-          parsed[header[1].trim().toLowerCase()] = header[2].trim();
+          if (headers.hasOwnProperty(h)) {
+            parsed[header[1].trim().toLowerCase()] = header[2].trim();
+          }
         }
       }
       return parsed;


### PR DESCRIPTION
Fix for evrythng.js work in Adobe Experience Manager (AEM). In Author mode, the AEM add on Array.prototype the function 'remove'. That include the "extra" value on headers array, generating an exception in for..in loop.
