### PR TITLE
Add param setter, support permission names, file.upload method

### DIFF
--- a/src/entity/File.js
+++ b/src/entity/File.js
@@ -16,10 +16,36 @@ export default class File extends Entity {
    * @return {{file: Function}}
    */
   static resourceFactory () {
-    // TODO enable Node.js File streams and multipart/form-data files/blobs
-
     return {
-      file: Resource.factoryFor(File, path)
+      file (id) {
+        return Object.assign(
+          Resource.factoryFor(File, path).call(this, id),
+          {
+            upload
+          }
+        )
+      }
     }
   }
+}
+
+/**
+ * Upload file data, previously obtained from disk or the user.
+ *
+ * Note: Only text or encoded text is currently supported here.
+ *
+ * @param {*} data - Data as buffer or string.
+ */
+async function upload (data) {
+  const resource = await this.read()
+  const opts = {
+    method: 'put',
+    headers: {
+      'Content-Type': resource.type,
+      'x-amz-acl': resource.privateAccess ? 'private' : 'public-read'
+    },
+    body: data
+  }
+
+  return fetch(resource.uploadUrl, opts)
 }

--- a/src/entity/Permission.js
+++ b/src/entity/Permission.js
@@ -19,18 +19,13 @@ export default class Permission extends Entity {
    */
   static resourceFactory () {
     return {
-      permission () {
-        // Permissions don't have single resource endpoint (e.g.: /permissions/:id)
-        if (isString(arguments[0])) {
-          throw new TypeError('There is no single resource for Permissions')
-        }
-
+      permission (name) {
         // Only allowed on Entities and Resources.
         if (this instanceof Scope) {
           throw new Error('Permission is not a top-level resource.')
         }
 
-        return Resource.factoryFor(Permission, path).call(this)
+        return Resource.factoryFor(Permission, path).call(this, name)
       }
     }
   }

--- a/src/resource/Resource.js
+++ b/src/resource/Resource.js
@@ -221,6 +221,19 @@ export default class Resource {
   }
 
   /**
+   * Helper for the 'ids' param.
+   *
+   * E.g: user.thng().setIds(['UNREK4bCUSCdGpRwaKMfdPfs', 'U7xPy2xqkbHyskaaR3MQUgrh']).read()
+   *
+   * @param {string[]} ids - Array of IDs.
+   * @returns {Resource} this
+   */
+  setIds (ids) {
+    this.preParams.ids = ids
+    return this
+  }
+
+  /**
    * Create a new entity for this resource.
    *
    * @param {Object|Entity} data - Entity to create

--- a/test/e2e/entity/files.spec.js
+++ b/test/e2e/entity/files.spec.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const { expect } = require('chai')
 const { getScope } = require('../util')
 
@@ -12,7 +13,8 @@ module.exports = () => {
     it('should create a file', async () => {
       const payload = {
         name: 'TestFile.txt',
-        type: 'text/plain'
+        type: 'text/plain',
+        privateAccess: false
       }
 
       file = await operator.file().create(payload)
@@ -21,7 +23,7 @@ module.exports = () => {
       expect(file.type).to.deep.equal(payload.type)
     })
 
-    it('should read all batches', async () => {
+    it('should read all files', async () => {
       const res = await operator.file().read()
 
       expect(res).to.be.an('array')
@@ -34,6 +36,19 @@ module.exports = () => {
       expect(res).to.be.an('object')
       expect(res.id).to.equal(file.id)
     })
+
+    it('should upload file content - text', async () => {
+      const data = 'This is example text file content'
+
+      await operator.file(file.id).upload(data)
+
+      const resource = await operator.file(file.id).read()
+      const readData = await fetch(resource.contentUrl).then(res => res.text())
+
+      expect(readData).to.equal(data)
+    })
+
+    it('should upload file content - image data')
 
     it('should delete a file', async () => {
       await operator.file(file.id).delete()

--- a/test/e2e/entity/permissions.spec.js
+++ b/test/e2e/entity/permissions.spec.js
@@ -21,6 +21,23 @@ const describeOperatorPermissionTests = () => {
       expect(res).to.have.length.gte(2)
       expect(res[0].name).to.equal('global_read')
     })
+
+    it('should read a single role permission', async () => {
+      const name = 'global_read'
+      const res = await operator.role(role.id).permission(name).read()
+
+      expect(res).to.be.an('object')
+      expect(res.name).to.equal(name)
+    })
+
+    it('should update a single role permission', async () => {
+      const name = 'global_read'
+      const payload = { name, enabled: false }
+      const res = await operator.role(role.id).permission(name).update(payload)
+
+      expect(res).to.be.an('object')
+      expect(res.enabled).to.equal(false)
+    })
   })
 }
 

--- a/test/e2e/misc/paramSetters.spec.js
+++ b/test/e2e/misc/paramSetters.spec.js
@@ -59,6 +59,14 @@ module.exports = () => {
       expect(res).to.have.length.gte(1)
     })
 
+    it('should set ids via setIds', async () => {
+      const thng2 = await operator.thng().create({ name: 'Test' })
+      const ids = (await operator.thng().read()).map(p => p.id)
+
+      const res = await operator.thng().setIds(ids).read()
+      expect(res.length).to.equal(ids.length)
+    })
+
     it('should allow chaining of multiple param setters', async () => {
       const res = await operator.thng()
         .setProject(project.id)


### PR DESCRIPTION
* Add missing `setIds()` param setter.
* Support referring to `permission` by name, such as `permission('global_read')`
* Add `upload()` method for files to upload file data.