### PR TITLE
Support find/upsert by 'name' and bump version for v5.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Official Javascript SDK for the EVRYTHNG API.",
   "main": "./dist/evrythng.node.js",
   "scripts": {

--- a/test/e2e/misc/find.spec.js
+++ b/test/e2e/misc/find.spec.js
@@ -21,7 +21,7 @@ module.exports = () => {
       await operator.thng(thng.id).delete()
     })
 
-    it('should find Thngs', async () => {
+    it('should find Thngs by identifiers', async () => {
       const res = await operator.thng().find(payload.identifiers)
 
       expect(res).to.be.an('array')
@@ -33,6 +33,13 @@ module.exports = () => {
 
       const attempt = operator.thng().find(payload.identifiers)
       return expect(attempt).to.eventually.be.rejected
+    })
+
+    it('should find Thngs by name', async () => {
+      const res = await operator.thng().find(payload.name)
+
+      expect(res).to.be.an('array')
+      expect(res).to.have.length.gte(1)
     })
   })
 }

--- a/test/e2e/misc/upsert.spec.js
+++ b/test/e2e/misc/upsert.spec.js
@@ -9,39 +9,38 @@ const payload = { name: 'Test Thng', identifiers: { serial: `s-${Date.now()}` } 
 
 module.exports = () => {
   describe('upsert', () => {
-    let operator, thng, duplicate, originalId
+    let operator, thng1, thng2, thng3
 
     before(async () => {
       operator = getScope('operator')
     })
 
     after(async () => {
-      await operator.thng(thng.id).delete()
-      await operator.thng(duplicate.id).delete()
+      await operator.thng(thng1.id).delete()
+      await operator.thng(thng2.id).delete()
+      await operator.thng(thng3.id).delete()
     })
 
-    it('should create a Thng', async () => {
-      const res = await operator.thng().upsert(payload, payload.identifiers)
-      originalId = `${res.id}`
-      thng = res
+    it('should create a Thng by identifiers', async () => {
+      thng1 = await operator.thng().upsert(payload, payload.identifiers)
 
-      expect(res).to.be.an('object')
-      expect(res.name).to.equal(payload.name)
-      expect(res.identifiers).to.deep.equal(payload.identifiers)
+      expect(thng1).to.be.an('object')
+      expect(thng1.name).to.equal(payload.name)
+      expect(thng1.identifiers).to.deep.equal(payload.identifiers)
     })
 
-    it('should update the same Thng', async () => {
+    it('should update the same Thng by identifiers', async () => {
       payload.name = 'Updated Thng'
       const res = await operator.thng().upsert(payload, payload.identifiers)
 
       expect(res).to.be.an('object')
-      expect(res.id).to.equal(originalId)
+      expect(res.id).to.equal(thng1.id)
       expect(res.name).to.equal(payload.name)
       expect(res.createdAt).to.not.equal(res.updatedAt)
     })
 
     it('should refuse to update if more than one Thng is found', async () => {
-      duplicate = await operator.thng().create(payload)
+      thng2 = await operator.thng().create(payload)
 
       const attempt = operator.thng().upsert(payload, payload.identifiers)
       return expect(attempt).to.eventually.be.rejected
@@ -52,9 +51,29 @@ module.exports = () => {
       const res = await operator.thng().upsert(payload, payload.identifiers, true)
 
       expect(res).to.be.an('object')
-      expect(res.id).to.equal(duplicate.id)
+      expect(res.id).to.equal(thng2.id)
       expect(res.name).to.equal(payload.name)
       expect(res.createdAt).to.not.equal(res.updatedAt)
+    })
+
+    it('should create a Thng by name', async () => {
+      payload.name = `Thng ${Date.now()}`
+      thng3 = await operator.thng().upsert(payload, payload.name)
+
+      expect(thng3).to.be.an('object')
+      expect(thng3.name).to.equal(payload.name)
+      expect(thng3.identifiers).to.deep.equal(payload.identifiers)
+    })
+
+    it('should update a Thng by name', async () => {
+      payload.tags = ['test', 'tags']
+      const res = await operator.thng().upsert(payload, payload.name)
+
+      expect(res).to.be.an('object')
+      expect(res.id).to.equal(thng3.id)
+      expect(res.name).to.equal(payload.name)
+      expect(res.createdAt).to.not.equal(res.updatedAt)
+      expect(res.tags).to.deep.equal(payload.tags)
     })
   })
 }


### PR DESCRIPTION
1. Support `find()` and `upsert()` by `name` instead of just an `identifier` object.
2. Bump version to 5.3.0