### PR TITLE
Better handle a non-standard empty response body

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -129,20 +129,28 @@ function makeFetch (options) {
  * @returns {Promise} - Promise to {Response} or {Object}
  */
 function handleResponse (options) {
-  return response => {
+  return async (response) => {
     const res = options.fullResponse
+      // Full response requested by user
       ? Promise.resolve(response)
       : response.status === 204 || options.method.toLowerCase() === 'delete'
+        // Accepted or DELETE requests have no body
         ? Promise.resolve()
+        // Attempt to decode the response JSON body
         : response.json()
 
-    return res.then(data => {
-      if (response.ok) {
-        return data
-      } else {
-        throw data
-      }
-    })
+    let data = ''
+    try {
+      data = await res
+    } catch (e) {
+      // Non-standard empty body response, allow it
+    }
+
+    if (!response.ok) {
+      throw data
+    }
+
+    return data
   }
 }
 


### PR DESCRIPTION
Requests like POST to _Add collections to a collection_ return no response body. This stops the SDK exploding if such a situation occurs and lets the user handle the empty response themselves.