### PR TITLE
Use short domain API instead of .../redirector for Thng/product redirections

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import * as evrythng from 'evrythng'
 Or use a simple script tag to load it from the CDN.
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.2.0/evrythng-5.2.0.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.4.0/evrythng-5.4.0.js"></script>
 ```
 
 Then use in a browser `script` tag using the `evrythng` global variable:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Official Javascript SDK for the EVRYTHNG API.",
   "main": "./dist/evrythng.node.js",
   "scripts": {

--- a/src/entity/Product.js
+++ b/src/entity/Product.js
@@ -26,7 +26,7 @@ export default class Product extends ProductResources(Entity) {
    */
   static resourceFactory () {
     return {
-      product: Resource.factoryFor(Product, path, ProductResources)
+      product: Resource.factoryFor(Product, path, ProductResources, 'product')
     }
   }
 }

--- a/src/entity/Redirection.js
+++ b/src/entity/Redirection.js
@@ -3,8 +3,6 @@ import Resource from '../resource/Resource'
 import Scope from '../scope/Scope'
 import isString from 'lodash-es/isString'
 
-const path = '/redirector'
-
 /**
  * Represents a Redirection entity.
  *
@@ -19,10 +17,10 @@ export default class Redirection extends Entity {
    */
   static resourceFactory () {
     return {
-      redirection () {
-        // Redirections don't have single resource endpoint (e.g.: /redirector/:id)
-        if (isString(arguments[0])) {
-          throw new TypeError('There is no single resource for Redirections')
+      redirection (shortDomain) {
+        // Redirections don't have single resource endpoint
+        if (!isString(arguments[0])) {
+          throw new TypeError('You must specify a shortDomain in redirection()')
         }
 
         // Only allowed on Entities and Resources.
@@ -30,7 +28,65 @@ export default class Redirection extends Entity {
           throw new Error('Redirection is not a top-level resource.')
         }
 
-        return Resource.factoryFor(Redirection, path).call(this)
+        /**
+         * Helper for repetitive shortDomain focussed requests.
+         *
+         * @param {object} changes - Additional options.
+         * @returns {Promise<object>} API response.
+         */
+        const shortDomainRequest = async changes =>
+          Resource.prototype._request.call(_this, Object.assign({
+            apiUrl: `https://${shortDomain}`,
+            url: '/redirections',
+            headers: {
+              Accept: 'application/json'
+            }
+          }, changes))
+
+        // Special case: use the shortDomain API instead of the /redirector API.
+        const _this = this
+        return {
+          create (payload) {
+            payload.evrythngId = _this.id
+            payload.type = _this.typeName
+
+            return shortDomainRequest({
+              method: 'post',
+              body: JSON.stringify(payload)
+            })
+          },
+          async read () {
+            const [first] = await shortDomainRequest({
+              params: { evrythngId: _this.id }
+            })
+            return first
+          },
+          async update (payload) {
+            const existing = await this.read()
+            if (!existing) {
+              return this.create(payload)
+            }
+
+            // Else update it
+            return shortDomainRequest({
+              url: `/redirections/${existing.shortId}`,
+              method: 'put',
+              body: JSON.stringify(payload)
+            })
+          },
+          async delete () {
+            const existing = await this.read()
+            if (!existing) {
+              return Promise.resolve()
+            }
+
+            // Else delete it
+            return shortDomainRequest({
+              url: `/redirections/${existing.shortId}`,
+              method: 'delete'
+            })
+          }
+        }
       }
     }
   }

--- a/src/entity/Redirection.js
+++ b/src/entity/Redirection.js
@@ -28,6 +28,8 @@ export default class Redirection extends Entity {
           throw new Error('Redirection is not a top-level resource.')
         }
 
+        const _this = this
+
         /**
          * Helper for repetitive shortDomain focussed requests.
          *
@@ -44,9 +46,13 @@ export default class Redirection extends Entity {
           }, changes))
 
         // Special case: use the shortDomain API instead of the /redirector API.
-        const _this = this
         return {
-          create (payload) {
+          /**
+           * Create the redirection.
+           *
+           * @param {object} payload - Redirection payload.
+           */
+          async create (payload) {
             payload.evrythngId = _this.id
             payload.type = _this.typeName
 
@@ -55,12 +61,22 @@ export default class Redirection extends Entity {
               body: JSON.stringify(payload)
             })
           },
+
+          /**
+           * Read the redirection.
+           */
           async read () {
             const [first] = await shortDomainRequest({
               params: { evrythngId: _this.id }
             })
             return first
           },
+
+          /**
+           * Update the redirection. If it doesn't exist, it is created.
+           *
+           * @param {object} payload - Redirection update payload.
+           */
           async update (payload) {
             const existing = await this.read()
             if (!existing) {
@@ -74,6 +90,10 @@ export default class Redirection extends Entity {
               body: JSON.stringify(payload)
             })
           },
+
+          /**
+           * Delete the redirection, if it exists.
+           */
           async delete () {
             const existing = await this.read()
             if (!existing) {

--- a/src/entity/Redirection.js
+++ b/src/entity/Redirection.js
@@ -1,7 +1,8 @@
+import isString from 'lodash-es/isString'
 import Entity from './Entity'
 import Resource from '../resource/Resource'
 import Scope from '../scope/Scope'
-import isString from 'lodash-es/isString'
+import settings from '../settings'
 
 /**
  * Represents a Redirection entity.
@@ -17,12 +18,7 @@ export default class Redirection extends Entity {
    */
   static resourceFactory () {
     return {
-      redirection (shortDomain) {
-        // Redirections don't have single resource endpoint
-        if (!isString(arguments[0])) {
-          throw new TypeError('You must specify a shortDomain in redirection()')
-        }
-
+      redirection (shortDomain = settings.defaultShortDomain) {
         // Only allowed on Entities and Resources.
         if (this instanceof Scope) {
           throw new Error('Redirection is not a top-level resource.')

--- a/src/entity/Thng.js
+++ b/src/entity/Thng.js
@@ -28,7 +28,7 @@ export default class Thng extends ThngResources(Entity) {
    */
   static resourceFactory () {
     return {
-      thng: Resource.factoryFor(Thng, path, ThngResources)
+      thng: Resource.factoryFor(Thng, path, ThngResources, 'thng')
     }
   }
 }

--- a/src/resource/Resource.js
+++ b/src/resource/Resource.js
@@ -24,7 +24,7 @@ export default class Resource {
    * @param {string} path - Path for new resource
    * @param {Function} MixinNestedResources - Mixin that extends Resource class
    *                                          with nested resources.
-   * @param {string} typeName - Name of the entity posessing this resource.
+   * @param {string} [typeName] - Name of the entity posessing this resource.
    * @return {Function} - Resource factory function
    */
   static factoryFor (type, path = '', MixinNestedResources, typeName) {
@@ -75,7 +75,7 @@ export default class Resource {
    * @param {string} path - Relative path to API resource
    * @param {Entity} [type] - Reference to Entity class (constructor)
    * @param {string} [id] - The resource ID, if specified.
-   * @param {string} typeName - Name of the entity posessing this resource.
+   * @param {string} [typeName] - Name of the entity posessing this resource.
    */
   constructor (scope, path, type, id, typeName) {
     if (!(scope && scope instanceof Scope)) {

--- a/src/resource/Resource.js
+++ b/src/resource/Resource.js
@@ -23,10 +23,11 @@ export default class Resource {
    * @param {Entity} type - Entity sub-class
    * @param {string} path - Path for new resource
    * @param {Function} MixinNestedResources - Mixin that extends Resource class
-   * with nested resources
+   *                                          with nested resources.
+   * @param {string} typeName - Name of the entity posessing this resource.
    * @return {Function} - Resource factory function
    */
-  static factoryFor (type, path = '', MixinNestedResources) {
+  static factoryFor (type, path = '', MixinNestedResources, typeName) {
     if (!type) {
       throw new Error('Entity type is necessary for resource factory.')
     }
@@ -60,7 +61,7 @@ export default class Resource {
       const XResource = MixinNestedResources
         ? MixinNestedResources(Resource)
         : Resource
-      return new XResource(parentScope, newPath, type)
+      return new XResource(parentScope, newPath, type, id, typeName)
     }
   }
 
@@ -73,8 +74,10 @@ export default class Resource {
    * @param {Scope} scope - Scope containing API Key
    * @param {string} path - Relative path to API resource
    * @param {Entity} [type] - Reference to Entity class (constructor)
+   * @param {string} [id] - The resource ID, if specified.
+   * @param {string} typeName - Name of the entity posessing this resource.
    */
-  constructor (scope, path, type) {
+  constructor (scope, path, type, id, typeName) {
     if (!(scope && scope instanceof Scope)) {
       throw new TypeError('Scope should inherit from Scope (e.g. EVT.Application).')
     }
@@ -91,6 +94,12 @@ export default class Resource {
 
     // Allow chainable parameter hepers
     this.preParams = {}
+
+    // Remember the resource ID if specified
+    this.id = id
+
+    // Some sub-resources need to know what they belong to
+    this.typeName = typeName
 
     // Setup entity for serializing and deserializing results. It must
     // implement *toJSON()* method, as defined in the Entity base class.

--- a/src/resource/Resource.js
+++ b/src/resource/Resource.js
@@ -92,7 +92,7 @@ export default class Resource {
     // Setup path and allow to omit leading '/'.
     this.path = `${path[0] !== '/' ? '/' : ''}${path}`
 
-    // Allow chainable parameter hepers
+    // Allow chainable parameter helpers
     this.preParams = {}
 
     // Remember the resource ID if specified

--- a/src/settings.js
+++ b/src/settings.js
@@ -3,8 +3,8 @@
  * before and after each request, respectively.
  *
  * @typedef {Object} Interceptor
- * @param {Function} request - Function to run before the request is sent
- * @param {Function} response - Function to run after the response is received
+ * @property {Function} request - Function to run before the request is sent
+ * @property {Function} response - Function to run after the response is received
  */
 
 /**
@@ -12,16 +12,17 @@
  * Available options are provided below:
  *
  * @typedef {Object} Settings
- * @param {string} apiUrl - API url of request
- * @param {string} url - Url relative to `apiUrl`
- * @param {string} method - HTTP Method of request
- * @param {string} apiKey - API Key to use with request
- * @param {boolean} fullResponse - Flags if request should remain unwrapped
- * @param {boolean} geolocation - Flags if action creation should use the Web
+ * @property {string} apiUrl - API url of request
+ * @property {string} url - Url relative to `apiUrl`
+ * @property {string} method - HTTP Method of request
+ * @property {string} apiKey - API Key to use with request
+ * @property {boolean} fullResponse - Flags if request should remain unwrapped
+ * @property {boolean} geolocation - Flags if action creation should use the Web
  * Geolocation API
- * @param {number} timeout - Timeout for request
- * @param {Object} headers - Headers to send with request
- * @param {Interceptor[]} interceptors - List of request/response interceptors
+ * @property {number} timeout - Timeout for request
+ * @property {Object} headers - Headers to send with request
+ * @property {Interceptor[]} interceptors - List of request/response interceptors
+ * @property {string} defaultShortDomain - Default short domain to use for redirections
  */
 
 /**
@@ -38,7 +39,8 @@ const defaultSettings = {
   headers: {
     'content-type': 'application/json'
   },
-  interceptors: []
+  interceptors: [],
+  defaultShortDomain: 'tn.gg'
 }
 
 // Initialize settings with defaults.

--- a/test/e2e/entity/redirection.spec.js
+++ b/test/e2e/entity/redirection.spec.js
@@ -1,7 +1,8 @@
 const { expect } = require('chai')
 const { getScope } = require('../util')
 
-const defaultRedirectUrl = 'https://google.com?item={shortId}'
+const shortDomain = 'tn.gg'
+const defaultRedirectUrl = 'https://google.com'
 
 module.exports = (scopeType, targetType) => {
   let scope, target
@@ -19,14 +20,14 @@ module.exports = (scopeType, targetType) => {
 
     it(`should create a ${targetType} redirection`, async () => {
       const payload = { defaultRedirectUrl }
-      const res = await scope[targetType](target.id).redirection().create(payload)
+      const res = await scope[targetType](target.id).redirection(shortDomain).create(payload)
 
       expect(res).to.be.an('object')
       expect(res.updatedAt).to.be.lte(Date.now())
     })
 
     it(`should read a ${targetType} redirection`, async () => {
-      const res = await scope[targetType](target.id).redirection().read()
+      const res = await scope[targetType](target.id).redirection(shortDomain).read()
 
       expect(res.updatedAt).to.be.lte(Date.now())
       expect(res.hits).to.equal(0)
@@ -34,13 +35,13 @@ module.exports = (scopeType, targetType) => {
 
     it(`should update a ${targetType} redirection`, async () => {
       const payload = { defaultRedirectUrl: 'https://google.com/updated?item={shortId}' }
-      const res = await scope[targetType](target.id).redirection().update(payload)
+      const res = await scope[targetType](target.id).redirection(shortDomain).update(payload)
 
       expect(res.updatedAt).to.be.lte(Date.now())
     })
 
     it(`should delete a ${targetType} redirection`, async () => {
-      await scope[targetType](target.id).redirection().delete()
+      await scope[targetType](target.id).redirection(shortDomain).delete()
     })
   })
 }

--- a/test/e2e/entity/redirection.spec.js
+++ b/test/e2e/entity/redirection.spec.js
@@ -20,13 +20,20 @@ module.exports = (scopeType, targetType) => {
 
     it(`should create a ${targetType} redirection`, async () => {
       const payload = { defaultRedirectUrl }
-      const res = await scope[targetType](target.id).redirection(shortDomain).create(payload)
+      const res = await scope[targetType](target.id).redirection().create(payload)
 
       expect(res).to.be.an('object')
       expect(res.updatedAt).to.be.lte(Date.now())
     })
 
     it(`should read a ${targetType} redirection`, async () => {
+      const res = await scope[targetType](target.id).redirection().read()
+
+      expect(res.updatedAt).to.be.lte(Date.now())
+      expect(res.hits).to.equal(0)
+    })
+
+    it(`should read a ${targetType} redirection with explicit shortDomain`, async () => {
       const res = await scope[targetType](target.id).redirection(shortDomain).read()
 
       expect(res.updatedAt).to.be.lte(Date.now())
@@ -35,13 +42,13 @@ module.exports = (scopeType, targetType) => {
 
     it(`should update a ${targetType} redirection`, async () => {
       const payload = { defaultRedirectUrl: 'https://google.com/updated?item={shortId}' }
-      const res = await scope[targetType](target.id).redirection(shortDomain).update(payload)
+      const res = await scope[targetType](target.id).redirection().update(payload)
 
       expect(res.updatedAt).to.be.lte(Date.now())
     })
 
     it(`should delete a ${targetType} redirection`, async () => {
-      await scope[targetType](target.id).redirection(shortDomain).delete()
+      await scope[targetType](target.id).redirection().delete()
     })
   })
 }


### PR DESCRIPTION
Before, the `/thngs/:id/redirector` endpoint was used, which always required some of `{shortId}` or `{thngId}`/`{productId}` as part of the chosen redirection URL.

Now, the same endpoint as the Dashboard is used - the short domain API (such as `tn.gg`) to manage Thng/product resources, and no such templating is required (it's usually not used for SKU-level redirections, for example).

Because each short domain has its own API, this knowledge is required when modifying a resource's redirection. If not specified, `settings.defaultShortDomain` is used. For example:

```js
operator.thng(id)
  .redirection('tn.gg')
  .update({ defaultRedirectUrl: 'https://evrythng.com' })`
```

instead of

```js
operator.thng(id)
  .redirection()
  .update({ defaultRedirectUrl: 'https://evrythng.com' })`
```

The default can be set globally:

```js
evrythng.setup({ defaultShortDomain: 'x.tn.gg' });
```

Short domains can be discovered using `operator.sharedAccount(id).shortDomain().read()`.