### PR TITLE
Always throw a parsable native Error

### DIFF
--- a/src/util/callback.js
+++ b/src/util/callback.js
@@ -20,6 +20,9 @@ export function success (callback) {
 export function failure (callback) {
   return err => {
     if (callback) callback(err)
-    throw err
+
+    // Throw a native Error to play nicer with error handling/retry libraries
+    // Bonus: no need to check both e.message and e.errors
+    throw new Error(err.message || JSON.stringify(err))
   }
 }

--- a/test/e2e/misc/api.spec.js
+++ b/test/e2e/misc/api.spec.js
@@ -39,5 +39,18 @@ module.exports = () => {
       // Delete
       await _api(`/thngs/${thng.id}`, 'delete')
     })
+
+    it('should throw a native Error', async () => {
+      try {
+        await _api('/thngs', 'post', { foo: 'bar' })
+      } catch (e) {
+        expect(e.message).to.be.a('string')
+
+        const json = JSON.parse(e.message)
+        expect(json.errors).to.be.an('array')
+        expect(json.moreInfo).to.be.a('string')
+        expect(json.status).to.be.a('number')
+      }
+    })
   })
 }


### PR DESCRIPTION
For example `p-retry` complains that `[Object object]` was thrown instead of an error.

This fixes that. From now on, `e.message` will always be valid, instead of checking `e.message  || e.errors` as before. The API error can be accessed by `JSON.parse(e.message)`