### PR TITLE
Add Resource.stream() and tests

### DIFF
--- a/src/resource/Resource.js
+++ b/src/resource/Resource.js
@@ -440,9 +440,9 @@ export default class Resource {
     let page
     let willStop
 
-    while ((!(page = await iterator.next()).done)) {
+    while (!(page = await iterator.next()).done) {
       for (let i = 0; i < page.value.length; i += 1) {
-        if (willStop) {
+        if (typeof willStop === 'boolean' && willStop) {
           return
         }
 

--- a/src/resource/Resource.js
+++ b/src/resource/Resource.js
@@ -426,6 +426,33 @@ export default class Resource {
     return this.read({ params })
   }
 
+  /**
+   * Stream a set of resources, calling an async function for each item.
+   *
+   * The callback is passed the item and cumulative item index. If iteration should
+   * stop, the callback should return `true`.
+   *
+   * @param {function} eachItemCb - Async function to call for each item.
+   */
+  async stream (eachItemCb) {
+    const iterator = this.pages()
+    let totalSoFar = 0
+    let page
+    let willStop
+
+    while ((!(page = await iterator.next()).done)) {
+      for (let i = 0; i < page.value.length; i += 1) {
+        if (willStop) {
+          return
+        }
+
+        willStop = await eachItemCb(page.value[i], totalSoFar + i)
+      }
+
+      totalSoFar += page.value.length
+    }
+  }
+
   // PRIVATE
 
   /**

--- a/test/e2e/index.spec.js
+++ b/test/e2e/index.spec.js
@@ -91,6 +91,7 @@ describe('evrythng.js', () => {
     require('./misc/pages.spec')('operator')
     require('./misc/paramSetters.spec')()
     require('./misc/rescope.spec')()
+    require('./misc/stream.spec')()
     require('./misc/upsert.spec')()
     require('./misc/use.spec')()
   })

--- a/test/e2e/misc/stream.spec.js
+++ b/test/e2e/misc/stream.spec.js
@@ -1,0 +1,35 @@
+const { expect } = require('chai')
+const { getScope } = require('../util')
+
+const payload = { name: 'Test Thng', identifiers: { serial: '78fd6hsd' } }
+
+module.exports = () => {
+  describe('stream', () => {
+    let operator, thng, thng2
+
+    before(async () => {
+      operator = getScope('operator')
+
+      thng = await operator.thng().create(payload)
+      thng2 = await operator.thng().create(payload)
+    })
+
+    after(async () => {
+      await operator.thng(thng.id).delete()
+      await operator.thng(thng2.id).delete()
+    })
+
+    it('should stream Thngs once at a time', (done) => {
+      const cb = (item, index) => {
+        expect(item.id).to.have.length(24)
+
+        if (index === 2) {
+          done()
+          return true
+        }
+      }
+
+      operator.thng().stream(cb)
+    })
+  })
+}


### PR DESCRIPTION
Useful for iterating large collections of resources. Instead of:

```js
const iterator = operator.thng().setPerPage(5).pages();
let page;
while (!(page = await iterator.next()).done) {
  const promises = page.value.map((item, index) => {
    console.log(index, item.id);
  });
  await Promise.all(promises);
}
```

do this:

```js
operator.thng().setPerPage(5)
  .stream((item, index) => console.log(index, item.id));
```

The callback can end early if need be:

```js
const eachItemCb = async (item, index) => {
  if (item.id === LAST_ITEM_ID) {
    // Stop here please!
    return true;
  }

  await item.update(...);
};

await operator.product().stream(eachItemCb);
```