### PR TITLE
Add ActionApp scope and tests

### DIFF
--- a/src/evrythng.js
+++ b/src/evrythng.js
@@ -7,6 +7,7 @@ export { default as use } from './use'
 
 // Scopes
 export { default as Operator } from './scope/Operator'
+export { default as ActionApp } from './scope/ActionApp'
 export { default as Application } from './scope/Application'
 export { default as TrustedApplication } from './scope/TrustedApplication'
 export { default as User } from './scope/User'

--- a/src/scope/ActionApp.js
+++ b/src/scope/ActionApp.js
@@ -1,0 +1,136 @@
+import { mixinResources } from '../util/mixin'
+import Action from '../entity/Action'
+import api from '../api'
+import AppUser from '../entity/AppUser'
+import Scope from './Scope'
+import symbols from '../symbols'
+import User from './User'
+
+/** Action created on each page load automatially. **/
+const ACTION_TYPE_PAGE_VISITED = '_PageVisited'
+
+/**
+ * Mixin with all the top-level Application resources.
+ *
+ * @mixin
+ */
+const ApplicationAccess = mixinResources([
+  AppUser // C
+])
+
+/**
+ * ActionApp is a Scope similar to Application, but with helpers for the simple
+ * 'create anonymous user and actions for analytics' use case.
+ *
+ * @extends Scope
+ * @mixes ApplicationAccess
+ */
+export default class ActionApp extends ApplicationAccess(Scope) {
+  /**
+   * Creates an instance of ActionApp.
+   *
+   * @param {string} apiKey - Application API Key.
+   */
+  constructor (apiKey) {
+    super(apiKey)
+
+    this.init()
+  }
+
+  /**
+   * Read the application's data asynchronously, then prepare the anonymous user.
+   *
+   * @returns {Promise}
+   */
+  async init () {
+    const access = await super.init()
+    this.id = access.actor.id
+    this.project = access.project
+    this[symbols.path] = this._getPath()
+
+    await this.read()
+    this.anonUser = await this._getAnonUser()
+  }
+
+  /**
+   * Record that a page was visited. Make sure the _PageVisited action type is
+   * in the application's project scope. The URL is included in customFields.
+   *
+   * Use evrythng.setup() to disable geolocation if preferred.
+   *
+   * @returns {Promise}
+   */
+  async pageVisited () {
+    return this.createAction(ACTION_TYPE_PAGE_VISITED, { url: window.location.href })
+  }
+
+  /**
+   * Helper function to create an action with extra data.
+   *
+   * @param {string} type - Action Type. Must exist in Application project scope.
+   * @param {object} [data] - Optional extra action data associated with the web page.
+   * @returns {Promise}
+   */
+  async createAction (type, data = {}) {
+    if (!this.anonUser) {
+      throw new Error('Anonymous not yet loaded. Use ActionApp.init() to wait for this.')
+    }
+
+    // Check the action type is visible to the user
+    try {
+      await this.anonUser.actionType(type).read()
+    } catch (e) {
+      throw new Error('The action type was not found. Is it in project scope?')
+    }
+
+    return this.anonUser.action(type).create({ type, customFields: data })
+  }
+
+  // PRIVATE
+
+  /**
+   * Return application endpoint.
+   *
+   * @returns {string}
+   * @private
+   */
+  _getPath () {
+    return '/applications/me'
+  }
+
+  /**
+   * Store each user's API key according to the app they are using.
+   *
+   * @returns {string} A per-app localStorage key for the user.
+   */
+  _getStorageKey () {
+    return `action-app-user-${this.id}`
+  }
+
+  /**
+   * Create a new anonymous Application User and store in localStorage.
+   *
+   * @returns {Promise}
+   */
+  async _createAnonUser () {
+    const anonUser = await this.appUser().create({ anonymous: true })
+    localStorage.setItem(this._getStorageKey(), anonUser.evrythngApiKey)
+    return anonUser
+  }
+
+  /**
+   * Get the single anonymous Application User this scope uses to create actions.
+   * If none is stored in localStorage, a new one is created.
+   *
+   * @returns {Promise}
+   */
+  async _getAnonUser () {
+    const apiKey = localStorage.getItem(this._getStorageKey())
+    if (!apiKey) {
+      return this._createAnonUser()
+    }
+
+    const anonUser = new User(apiKey)
+    return anonUser.init()
+  }
+}

--- a/test/e2e/index.spec.js
+++ b/test/e2e/index.spec.js
@@ -84,6 +84,10 @@ describe('evrythng.js', () => {
     require('./scope/device.spec')()
   })
 
+  describe('as ActionApp', () => {
+    require('./scope/actionApp.spec')()
+  })
+
   describe('Misc', () => {
     require('./misc/alias.spec')()
     require('./misc/api.spec')('operator')

--- a/test/e2e/scope/actionApp.spec.js
+++ b/test/e2e/scope/actionApp.spec.js
@@ -1,0 +1,63 @@
+const { expect } = require('chai')
+const { getScope } = require('../util')
+const { ActionApp } = require('evrythng')
+
+const PAGE_VISITED = '_PageVisited'
+
+// Mocks
+global.localStorage = {
+  data: {},
+  getItem: key => global.localStorage.data[key],
+  setItem: (key, value) => {
+    global.localStorage.data[key] = value
+  },
+}
+global.window = {
+  location: { href: 'mocha test location' }
+}
+
+module.exports = () => {
+  describe('ActionApp', () => {
+    let operator, application, actionApp
+
+    before(async () => {
+      application = getScope('application')
+      operator = getScope('operator')
+      await operator.actionType().setProject(application.project).create({ name: PAGE_VISITED })
+
+      actionApp = new ActionApp(application.appApiKey)
+      await actionApp.init()
+    })
+
+    after(async () => {
+      await operator.actionType(PAGE_VISITED).delete()
+    })
+
+    it('should export helper functions', async () => {
+      expect(actionApp.pageVisited).to.be.a('function')
+      expect(actionApp.createAction).to.be.a('function')
+    })
+
+    it('should create a _PageVisited action with pageVisited()', async () => {
+      const res = await actionApp.pageVisited()
+
+      expect(res.id).to.have.length(24)
+      expect(res.type).to.equal(PAGE_VISITED)
+      expect(res.customFields.url).to.equal(global.window.location.href)
+    })
+
+    it('should create an action with custom data', async () => {
+      const res = await actionApp.createAction(PAGE_VISITED, { foo: 'bar' })
+
+      expect(res.type).to.equal(PAGE_VISITED)
+      expect(res.customFields.foo).to.equal('bar')
+    })
+
+    it('should re-use previous Application User credentials', async () => {
+      const otherActionApp = new ActionApp(application.appApiKey)
+      await otherActionApp.init()
+
+      expect(otherActionApp.anonUser.apiKey).to.equal(actionApp.anonUser.apiKey)
+    })
+  })
+}


### PR DESCRIPTION
To facilitate a common use case where an anonymous Application User is to be used to create actions related to user interactions with the web page and also be remembered. 

Instead of

```js
const app = new evrythng.Application(appApiKey)
await app.init()

/* Logic to remember the user's API Key in browser)...
 *
 * let user = await app.appUser().create({ anonymous: true })
 *
 * Logic to recall previously saved user's API key in browser)...
 *
 * let user = new evrythng.user(rememberedApiKey)
 */

// Create own utility function
window.createAction = (type, data) => user.action(type).create({ type, customFields: data })

// Record a page visited
user.action('_PageVisited').create({ url: window.location.href })

// Any other user interactions
createAction(type, data)
```

Use the utility scope:

```js
actionApp = new evrythng.ActionApp(appApiKey)

// Record a page visited
actionApp.pageVisited()

// any other user interactions
actionApp.createAction(type, data)
```