### PR TITLE
Add adiOrder + events resource to Operator, with tests

### DIFF
--- a/src/entity/ADIOrder.js
+++ b/src/entity/ADIOrder.js
@@ -1,0 +1,28 @@
+import Entity from './Entity'
+import ADIOrderEvent from './ADIOrderEvent'
+import Resource from '../resource/Resource'
+import { mixinResources } from '../util/mixin'
+
+const path = '/adis/orders'
+const ADIOrderResources = mixinResources([
+  ADIOrderEvent
+])
+
+/**
+ * Represents a ADIOrder entity object.
+ *
+ * @extends Entity
+ */
+export default class ADIOrder extends ADIOrderResources(Entity) {
+  /**
+   * Return simple resource factory for ADI Orders.
+   *
+   * @static
+   * @return {{adiOrder: Function}}
+   */
+  static resourceFactory () {
+    return {
+      adiOrder: Resource.factoryFor(ADIOrder, path, ADIOrderResources)
+    }
+  }
+}

--- a/src/entity/ADIOrderEvent.js
+++ b/src/entity/ADIOrderEvent.js
@@ -1,0 +1,23 @@
+import Entity from './Entity'
+import Resource from '../resource/Resource'
+
+const path = '/events'
+
+/**
+ * Represents a ADIOrderEvent entity object.
+ *
+ * @extends Entity
+ */
+export default class ADIOrderEvent extends Entity {
+  /**
+   * Return simple resource factory for ADI Order events.
+   *
+   * @static
+   * @return {{event: Function}}
+   */
+  static resourceFactory () {
+    return {
+      event: Resource.factoryFor(ADIOrderEvent, path)
+    }
+  }
+}

--- a/src/scope/Operator.js
+++ b/src/scope/Operator.js
@@ -1,5 +1,6 @@
 import Scope from './Scope'
 import Account from '../entity/Account'
+import ADIOrder from '../entity/ADIOrder'
 import Product from '../entity/Product'
 import Thng from '../entity/Thng'
 import Collection from '../entity/Collection'
@@ -23,6 +24,7 @@ import symbols from '../symbols'
  */
 const OperatorAccess = mixinResources([
   Account, // RU
+  ADIOrder,  // CR
   Product, // CRUD
   Thng, // CRUD
   Collection, // CRUD

--- a/test/e2e/entity/adiOrders.spec.js
+++ b/test/e2e/entity/adiOrders.spec.js
@@ -1,0 +1,96 @@
+const { expect } = require('chai')
+const nock = require('nock')
+const { getScope, mockApi } = require('../util')
+
+module.exports = () => {
+  describe('ADI Orders', () => {
+    let operator, order
+
+    before(() => {
+      operator = getScope('operator')
+    })
+
+    after(() => {
+      // Last use of nock right now
+      nock.cleanAll()
+      nock.enableNetConnect()
+    })
+
+    it('should create an ADI Order', async () => {
+      const payload = {
+        ids: [
+          'serial1',
+          'serial2'
+        ],
+        purchaseOrder: '234567890',
+        metadata: {
+          identifierKey: 'gs1:21',
+          customFields: {
+            factory: '0400321'
+          },
+          tags: [
+            'factory:0400321'
+          ],
+          shortDomain: 'tn.gg',
+          defaultRedirectUrl: 'https://evrythng.com?id={shortId}'
+        },
+        identifiers: {
+          internalId: 'X7JF'
+        },
+        tags: [
+          'X7JF'
+        ]
+      }
+
+      mockApi()
+        .post('/adis/orders', payload)
+        .reply(201, Object.assign({
+          id: 'UEp4rDGsnpCAF6xABbys5Amc'
+        }, payload))
+
+      order = await operator.adiOrder().create(payload)
+
+      expect(order).to.be.an('object')
+      expect(order.id).to.have.length(24)
+      expect(order.metadata.identifierKey).to.equal(payload.metadata.identifierKey)
+    })
+
+    it('should read an ADI Order by ID', async () => {
+      mockApi()
+        .get(`/adis/orders/${order.id}`)
+        .reply(200, order)
+
+      const res = await operator.adiOrder(order.id).read()
+
+      expect(order).to.be.an('object')
+      expect(order.id).to.have.length(24)
+    })
+
+    it('should create an ADI Order event', async () => {
+      const payload = {
+        metadata: {
+          type: 'encodings',
+          tags: ['example']
+        },
+        ids: [
+          'serial1',
+          'serial2'
+        ],
+        customFields: {
+          internalId: 'X7JF'
+        },
+        tags: ['X7JF']
+      }
+
+      mockApi()
+        .post(`/adis/orders/${order.id}/events`, payload)
+        .reply(201, Object.assign({ id: 'UrCPgMhMMmPEY6awwEf6gKfb' }, payload))
+
+      const res = await operator.adiOrder(order.id).event().create(payload)
+
+      expect(res).to.be.an('object')
+      expect(res.id).to.have.length(24)
+      expect(res.metadata.type).to.equal(payload.metadata.type)
+    })
+  })
+}

--- a/test/e2e/index.spec.js
+++ b/test/e2e/index.spec.js
@@ -49,6 +49,7 @@ describe('evrythng.js', () => {
     require('./entity/accounts.spec')()
     require('./entity/actions.spec')('operator')
     require('./entity/actionTypes.spec')('operator')
+    require('./entity/adiOrders.spec')()
     require('./entity/applicationRedirector.spec')()
     require('./entity/applications.spec')('operator')
     require('./entity/batches.spec')()

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -194,6 +194,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -267,6 +273,77 @@
         "@babel/runtime": "^7.4.3",
         "isomorphic-fetch": "^2.2.1",
         "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "1.7.3",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+              "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+              "requires": {
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
+              }
+            }
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+          "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+        }
       }
     },
     "execa": {
@@ -468,6 +545,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -594,6 +677,34 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nock": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -734,6 +845,12 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -743,6 +860,12 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "qs": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
+      "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "mocha": "^6.1.4"
+    "mocha": "^6.1.4",
+    "nock": "^10.0.6"
   }
 }

--- a/test/e2e/util.js
+++ b/test/e2e/util.js
@@ -1,5 +1,8 @@
 const { Operator, Application, TrustedApplication, Device, api } = require('evrythng')
+const nock = require('nock')
+
 const { OPERATOR_API_KEY } = process.env
+const API_URL = 'https://api.evrythng.com'
 
 let scopes = {}
 let resources = {}
@@ -64,9 +67,12 @@ const teardown = async () => {
 
 const getScope = type => scopes[type]
 
+const mockApi = () => nock(API_URL)
+
 module.exports = {
   resources,
   setup,
   teardown,
-  getScope
+  getScope,
+  mockApi
 }


### PR DESCRIPTION
Operator now has `.adiOrder()` and `.adiOrder(id).event()` methods for ADI Orders and order events.