### PR TITLE
Prevent scopes reading access twice

### DIFF
--- a/src/scope/ActionApp.js
+++ b/src/scope/ActionApp.js
@@ -43,7 +43,7 @@ export default class ActionApp extends ApplicationAccess(Scope) {
    * @returns {Promise}
    */
   async init () {
-    const access = await super.init()
+    const access = await super.readAccess()
     this.id = access.actor.id
     this.project = access.project
     this[symbols.path] = this._getPath()

--- a/src/scope/ActionApp.js
+++ b/src/scope/ActionApp.js
@@ -34,7 +34,17 @@ export default class ActionApp extends ApplicationAccess(Scope) {
   constructor (apiKey) {
     super(apiKey)
 
-    this.init()
+    this.initPromise = super.readAccess()
+      .then(access => {
+        this.id = access.actor.id
+        this.project = access.project
+        this[symbols.path] = this._getPath()
+      })
+      .then(() => this.read())
+      .then(() => this._getAnonUser())
+      .then(anonUser => {
+        this.anonUser = anonUser
+      })
   }
 
   /**
@@ -42,14 +52,8 @@ export default class ActionApp extends ApplicationAccess(Scope) {
    *
    * @returns {Promise}
    */
-  async init () {
-    const access = await super.readAccess()
-    this.id = access.actor.id
-    this.project = access.project
-    this[symbols.path] = this._getPath()
-
-    await this.read()
-    this.anonUser = await this._getAnonUser()
+  init () {
+    return this.initPromise
   }
 
   /**

--- a/src/scope/Application.js
+++ b/src/scope/Application.js
@@ -46,7 +46,13 @@ export default class Application extends ApplicationAccess(Scope) {
   constructor (apiKey, data = {}) {
     super(apiKey, data)
 
-    this.init()
+    this.initPromise = super.readAccess()
+      .then(access => {
+        this.id = access.actor.id
+        this.project = access.project
+        this[symbols.path] = this._getPath()
+      })
+      .then(() => this.read())
   }
 
   /**
@@ -55,13 +61,7 @@ export default class Application extends ApplicationAccess(Scope) {
    * @returns {Promise}
    */
   init () {
-    return super.readAccess()
-      .then(access => {
-        this.id = access.actor.id
-        this.project = access.project
-        this[symbols.path] = this._getPath()
-      })
-      .then(() => this.read())
+    return this.initPromise
   }
 
   /**

--- a/src/scope/Application.js
+++ b/src/scope/Application.js
@@ -55,7 +55,7 @@ export default class Application extends ApplicationAccess(Scope) {
    * @returns {Promise}
    */
   init () {
-    return super.init()
+    return super.readAccess()
       .then(access => {
         this.id = access.actor.id
         this.project = access.project

--- a/src/scope/Device.js
+++ b/src/scope/Device.js
@@ -42,7 +42,7 @@ export default class Device extends DeviceAccess(Scope) {
    * @returns {Promise}
    */
   init () {
-    return super.init()
+    return super.readAccess()
       .then(access => {
         this.id = access.actor.id
         this[symbols.path] = this._getPath()

--- a/src/scope/Device.js
+++ b/src/scope/Device.js
@@ -33,7 +33,12 @@ export default class Device extends DeviceAccess(Scope) {
   constructor (apiKey, data = {}) {
     super(apiKey, data)
 
-    this.init()
+    this.initPromise = super.readAccess()
+      .then(access => {
+        this.id = access.actor.id
+        this[symbols.path] = this._getPath()
+      })
+      .then(() => this.read())
   }
 
   /**
@@ -42,12 +47,7 @@ export default class Device extends DeviceAccess(Scope) {
    * @returns {Promise}
    */
   init () {
-    return super.readAccess()
-      .then(access => {
-        this.id = access.actor.id
-        this[symbols.path] = this._getPath()
-      })
-      .then(() => this.read())
+    return this.initPromise
   }
 
   // PRIVATE

--- a/src/scope/Operator.js
+++ b/src/scope/Operator.js
@@ -57,7 +57,11 @@ export default class Operator extends OperatorAccess(Scope) {
   constructor (apiKey, data = {}) {
     super(apiKey, data)
 
-    this.init()
+    this.initPromise = super.readAccess()
+      .then(access => {
+        this.id = access.actor.id
+        this[symbols.path] = this._getPath()
+      })
   }
 
   /**
@@ -66,11 +70,7 @@ export default class Operator extends OperatorAccess(Scope) {
    * @returns {Promise}
    */
   init () {
-    return super.readAccess()
-      .then(access => {
-        this.id = access.actor.id
-        this[symbols.path] = this._getPath()
-      })
+    return this.initPromise
   }
 
   // PRIVATE

--- a/src/scope/Operator.js
+++ b/src/scope/Operator.js
@@ -66,12 +66,11 @@ export default class Operator extends OperatorAccess(Scope) {
    * @returns {Promise}
    */
   init () {
-    return super.init()
+    return super.readAccess()
       .then(access => {
         this.id = access.actor.id
         this[symbols.path] = this._getPath()
       })
-      .then(() => this.read())
   }
 
   // PRIVATE

--- a/src/scope/Scope.js
+++ b/src/scope/Scope.js
@@ -30,7 +30,7 @@ export default class Scope {
    *
    * @returns {Promise}
    */
-  init () {
+  readAccess () {
     return api({
       url: '/access',
       apiKey: this.apiKey

--- a/src/scope/TrustedApplication.js
+++ b/src/scope/TrustedApplication.js
@@ -53,7 +53,8 @@ export default class TrustedApplication extends ApplicationAccess(Application) {
   constructor (apiKey, data = {}) {
     super(apiKey, data)
 
-    this.init()
+    // Operation is the same as for Application scope.
+    this.initPromise = super.init()
   }
 
   /**
@@ -62,8 +63,7 @@ export default class TrustedApplication extends ApplicationAccess(Application) {
    * @returns {Promise}
    */
   init () {
-    // Operation is the same as for Application scope.
-    return super.init()
+    return this.initPromise
   }
 
   /**

--- a/src/scope/User.js
+++ b/src/scope/User.js
@@ -54,7 +54,7 @@ export default class User extends AppUser(Scope) {
    * @returns {Promise}
    */
   init () {
-    return super.init()
+    return super.readAccess()
       .then(access => {
         this.id = access.actor.id
         this[symbols.path] = this._getPath()

--- a/src/scope/User.js
+++ b/src/scope/User.js
@@ -45,7 +45,12 @@ export default class User extends AppUser(Scope) {
   constructor (apiKey, data = {}) {
     super(apiKey, data)
 
-    this.init()
+    this.initPromise = super.readAccess()
+      .then(access => {
+        this.id = access.actor.id
+        this[symbols.path] = this._getPath()
+      })
+      .then(() => this.read())
   }
 
   /**
@@ -54,12 +59,7 @@ export default class User extends AppUser(Scope) {
    * @returns {Promise}
    */
   init () {
-    return super.readAccess()
-      .then(access => {
-        this.id = access.actor.id
-        this[symbols.path] = this._getPath()
-      })
-      .then(() => this.read())
+    return this.initPromise
   }
 
   /**


### PR DESCRIPTION
Before this change `new Operator` and `init()` would cause two identical calls to `GET /access`:

```js
// One call to super.init()
const op = new Operator(key)
// Second call to super.init()
await op.init()
```

Also clarify use of `Scope.readAccess` from individual scope's initialisation (two functions named `init` but do different things is confusing)