### PR TITLE
ActionApp scope improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# v5.8.0 (3-2-2020)
+
+## Features
+
+- **ActionApp**: Allow `createAction()` to target a `thng` or `product` by including an ID in the `data` parameter.
+
+- **ActionApp**: All `getAnonymousUser()` to allow usage of the managed anonymous Application User.
+
+
+## Fixes
+
+- **ActionApp**: Fix bug preventing use of built-in action types.
+
+
+# v5.7.1 (14-1-2020)
+
+## Features
+
+- **Pagination**: Add `streamPages()` to all resources to allow asynchronously streaming pages of resources.
+
+
 # v5.6.0 (27-9-2019)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ const data = { platform: 'android' }
 const thngId = getQueryParam('thng')
 const action = await actionApp.createAction('scans', data, thngId)
 
+// Log a page was visited (the current URL)
+await actionApp.pageVisited()
+
 // Retrieve the managed Application User
 const anonymousUser = await actionApp.getAnonymousUser()
 ```

--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ const userApiKey = localStorage.getItem('user_api_key')
 const user = new evrythng.User(userApiKey)
 ```
 
+* `ActionApp` - Special version of the Application scope designed to make it as
+  simple as possible to create instrumentation actions in web apps. It creates
+  and remembers an anonymous Application User in LocalStorage and provides a
+  simple interface for creating actions:
+
+```js
+import { ActionApp } from 'evrythng'
+
+const actionApp = new ActionApp(appApiKey)
+await actionApp.init()
+
+// Create a scan action on a Thng identified in the query
+const data = { platform: 'android' }
+const thngId = getQueryParam('thng')
+const action = await actionApp.createAction('scans', data, thngId)
+
+// Retrieve the managed Application User
+const anonymousUser = await actionApp.getAnonymousUser()
+```
+
 For any scope, if the scope's own data (such as an Application's `customFields`)
 is required immediately, use the `init()` method to wait until this data is
 available. If not, this step can be ignored:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import * as evrythng from 'evrythng'
 Or use a simple script tag to load it from the CDN.
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.7.1/evrythng-5.7.1.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.8.0/evrythng-5.8.0.js"></script>
 ```
 
 Then use in a browser `script` tag using the `evrythng` global variable:

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ const actionApp = new ActionApp(appApiKey)
 await actionApp.init()
 
 // Create a scan action on a Thng identified in the query
-const data = { platform: 'android' }
-const thngId = getQueryParam('thng')
-const action = await actionApp.createAction('scans', data, thngId)
+const thng = getQueryParam('thng')
+const data = { thng, userAgent }
+const action = await actionApp.createAction('scans', data)
 
 // Log a page was visited (the current URL)
 await actionApp.pageVisited()

--- a/package-lock.json
+++ b/package-lock.json
@@ -3653,9 +3653,9 @@
       "dev": true
     },
     "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc=",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
       "dev": true
     },
     "log-symbols": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build-dev": "webpack --config webpack.config.js --mode development",
     "show-notice": "echo '\n    New to evrythng.js v5? Make sure to read the migration guide:\n    https://developers.evrythng.com/docs/evrythngjs-v500\n'",
     "postinstall": "npm run --silent show-notice",
-    "test": "mocha test/e2e/index.spec.js"
+    "test": "mocha test/e2e/index.spec.js",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "fetch-mock": "^5.8.1",
-    "lodash-es": "^4.17.2",
+    "lodash-es": "^4.17.15",
     "mocha": "^6.2.0",
     "nock": "^11.3.3",
     "webpack": "^4.29.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "description": "Official Javascript SDK for the EVRYTHNG API.",
   "main": "./dist/evrythng.node.js",
   "scripts": {

--- a/src/scope/ActionApp.js
+++ b/src/scope/ActionApp.js
@@ -73,10 +73,10 @@ export default class ActionApp extends ApplicationAccess(Scope) {
    *
    * @param {string} type - Action Type. Must exist in Application project scope.
    * @param {Object} [data] - Optional extra action data associated with the web page.
-   * @param {string} thng - Thng to use as the target. Must exist in Application project scope.
-   * @returns {Promise}
+   *                          Add 'thng' or 'product' to set that ID as the action target.
+   * @returns {Promise<Object>} The action that was created.
    */
-  async createAction (type, data = {}, thng) {
+  async createAction (type, data = {}) {
     if (!this.anonUser) {
       throw new Error('Anonymous user not yet prepared. Use actionApp.init() to wait for this.')
     }
@@ -91,9 +91,17 @@ export default class ActionApp extends ApplicationAccess(Scope) {
       }
     }
 
-    const payload = { type, customFields: data }
+    const { thng, product, ...customFields } = data;
+    if (thng && product) {
+      throw new Error('Either thng or product can be specified as target, not both');
+    }
+
+    const payload = { type, customFields }
     if (thng) {
       payload.thng = thng
+    }
+    if (product) {
+      payload.product = product
     }
 
     return this.anonUser.action(type).create(payload)

--- a/src/scope/ActionApp.js
+++ b/src/scope/ActionApp.js
@@ -108,7 +108,7 @@ export default class ActionApp extends ApplicationAccess(Scope) {
   }
 
   /**
-   * Get the underlyiny anonymous Application User maintained in localStorage
+   * Get the underlying anonymous Application User maintained in localStorage
    * by this ActionApp.
    *
    * @returns {User} Anonymous Application User SDK Scope.

--- a/src/scope/ActionApp.js
+++ b/src/scope/ActionApp.js
@@ -72,22 +72,45 @@ export default class ActionApp extends ApplicationAccess(Scope) {
    * Helper function to create an action with extra data.
    *
    * @param {string} type - Action Type. Must exist in Application project scope.
-   * @param {object} [data] - Optional extra action data associated with the web page.
+   * @param {Object} [data] - Optional extra action data associated with the web page.
+   * @param {string} thng - Thng to use as the target. Must exist in Application project scope.
    * @returns {Promise}
    */
-  async createAction (type, data = {}) {
+  async createAction (type, data = {}, thng) {
     if (!this.anonUser) {
-      throw new Error('Anonymous not yet loaded. Use ActionApp.init() to wait for this.')
+      throw new Error('Anonymous user not yet prepared. Use actionApp.init() to wait for this.')
     }
 
-    // Check the action type is visible to the user
-    try {
-      await this.anonUser.actionType(type).read()
-    } catch (e) {
-      throw new Error('The action type was not found. Is it in project scope?')
+    if (type.includes('_')) {
+      // Check the custom action type is visible to the user
+      try {
+        await this.anonUser.actionType(type).read()
+      } catch (e) {
+        console.error(e);
+        throw new Error('The action type was not found. Is it in project scope?')
+      }
     }
 
-    return this.anonUser.action(type).create({ type, customFields: data })
+    const payload = { type, customFields: data }
+    if (thng) {
+      payload.thng = thng
+    }
+
+    return this.anonUser.action(type).create(payload)
+  }
+
+  /**
+   * Get the underlyiny anonymous Application User maintained in localStorage
+   * by this ActionApp.
+   *
+   * @returns {User} Anonymous Application User SDK Scope.
+   */
+  async getAnonymousUser () {
+    if (!this.anonUser) {
+      throw new Error('Anonymous user not yet prepared. Use actionApp.init() to wait for this.')
+    }
+
+    return this.anonUser;
   }
 
   // PRIVATE

--- a/src/scope/ActionApp.js
+++ b/src/scope/ActionApp.js
@@ -81,7 +81,7 @@ export default class ActionApp extends ApplicationAccess(Scope) {
       throw new Error('Anonymous user not yet prepared. Use actionApp.init() to wait for this.')
     }
 
-    if (type.includes('_')) {
+    if (type.startsWith('_')) {
       // Check the custom action type is visible to the user
       try {
         await this.anonUser.actionType(type).read()

--- a/test/e2e/scope/actionApp.spec.js
+++ b/test/e2e/scope/actionApp.spec.js
@@ -103,11 +103,33 @@ module.exports = () => {
           customFields: { foo: 'bar' }
         })
 
-      const res = await actionApp.createAction('scans', { foo: 'bar' }, thng)
+      const res = await actionApp.createAction('scans', { thng, foo: 'bar' })
 
       expect(res.type).to.equal('scans')
       expect(res.customFields.foo).to.equal('bar')
       expect(res.thng).to.equal('UKYDHeYCQbgDppRwRkHVMHhg')
+    })
+
+    it('should create an scans action with a product specified', async () => {
+      const product = 'UKYDHeYCQbgDppRwRkHVMHhg'
+      mockApi()
+        .post('/actions/scans', {
+          type: 'scans',
+          customFields: { foo: 'bar' },
+          product,
+        })
+        .reply(201, {
+          id: 'actionId',
+          type: 'scans',
+          product,
+          customFields: { foo: 'bar' }
+        })
+
+      const res = await actionApp.createAction('scans', { product, foo: 'bar' })
+
+      expect(res.type).to.equal('scans')
+      expect(res.customFields.foo).to.equal('bar')
+      expect(res.product).to.equal('UKYDHeYCQbgDppRwRkHVMHhg')
     })
 
     it('should re-use previous Application User credentials', async () => {

--- a/test/e2e/scope/actionApp.spec.js
+++ b/test/e2e/scope/actionApp.spec.js
@@ -79,7 +79,7 @@ module.exports = () => {
       expect(res.customFields.foo).to.equal('bar')
     })
 
-    it('should provide access to the undelying anonymous Application User', async () => {
+    it('should provide access to the underlying anonymous Application User', async () => {
       const anonUser = await actionApp.getAnonymousUser()
 
       expect(anonUser.id).to.be.a('string')
@@ -88,7 +88,7 @@ module.exports = () => {
       expect(anonUser.apiKey).to.have.length(80)
     })
 
-    it('should create an scans action with a Thng specified', async () => {
+    it('should create a scans action with a Thng specified', async () => {
       const thng = 'UKYDHeYCQbgDppRwRkHVMHhg'
       mockApi()
         .post('/actions/scans', {
@@ -110,7 +110,7 @@ module.exports = () => {
       expect(res.thng).to.equal('UKYDHeYCQbgDppRwRkHVMHhg')
     })
 
-    it('should create an scans action with a product specified', async () => {
+    it('should create a scans action with a product specified', async () => {
       const product = 'UKYDHeYCQbgDppRwRkHVMHhg'
       mockApi()
         .post('/actions/scans', {


### PR DESCRIPTION
* Don't read the action type provided if it's a built-in one (app users can't do this anyway)
* Allow `createAction()` to specify a Thng or product target using the `data` parameter. This is to preserve existing usages.
* Add `actionApp.getAnonymousUser()` to retrieve the anonymous Application User managed in `localStorage`.

```js
const actionApp = new evrythng.ActionApp(APPLICATION_API_KEY)

// Create a scan action on a Thng
const thng = getQueryParam('thng');
const data = { thng, platform: 'android' };
const action = await actionApp.createAction('scans', data);

// Get the app user to check `id` or `apiKey`
const anonymousUser = await actionApp.getAnonymousUser();
```

**Pre-release:**
- [x] Bump version to 5.8.0