### PR TITLE
Allow 5 minute old location data

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import * as evrythng from 'evrythng'
 Or use a simple script tag to load it from the CDN.
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.9.2/evrythng-5.9.2.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.9.3/evrythng-5.9.3.js"></script>
 ```
 
 Then use in a browser `script` tag using the `evrythng` global variable:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "description": "Official Javascript SDK for the EVRYTHNG API.",
   "main": "./dist/evrythng.node.js",
   "scripts": {

--- a/src/util/getCurrentPosition.js
+++ b/src/util/getCurrentPosition.js
@@ -9,7 +9,9 @@ const maximumAge = 5 * 60 * 1000;
  */
 export default function getCurrentPosition () {
   return new Promise((resolve, reject) => {
-    if (!window.navigator.geolocation) throw new Error('Geolocation API not available.')
+    if (typeof window === 'undefined' || !window.navigator.geolocation) {
+      throw new Error('Geolocation API not available.')
+    }
 
     const geolocationOptions = {
       maximumAge,

--- a/src/util/getCurrentPosition.js
+++ b/src/util/getCurrentPosition.js
@@ -1,3 +1,6 @@
+// Maximum acceptable age of cached location from the browser
+const maximumAge = 5 * 60 * 1000;
+
 /**
  * Get browser's current position from Geolocation API.
  *
@@ -6,20 +9,18 @@
  */
 export default function getCurrentPosition () {
   return new Promise((resolve, reject) => {
-    if (typeof window !== 'undefined' && window.navigator.geolocation) {
-      const geolocationOptions = {
-        maximumAge: 0,
-        timeout: 10000,
-        enableHighAccuracy: true
-      }
+    if (!window.navigator.geolocation) throw new Error('Geolocation API not available.')
 
-      window.navigator.geolocation.getCurrentPosition(
-        resolve,
-        err => reject(err),
-        geolocationOptions
-      )
-    } else {
-      throw new Error('Geolocation API not available.')
+    const geolocationOptions = {
+      maximumAge,
+      timeout: 10000,
+      enableHighAccuracy: true
     }
+
+    window.navigator.geolocation.getCurrentPosition(
+      resolve,
+      err => reject(err),
+      geolocationOptions
+    )
   })
 }

--- a/test/e2e/entity/files.spec.js
+++ b/test/e2e/entity/files.spec.js
@@ -38,7 +38,9 @@ module.exports = () => {
       expect(res.id).to.equal('fileId')
     })
 
-    it('should upload file content - text', async () => {
+    it('should upload file content - text', async function () {
+      this.timeout(10000);
+
       const fileData = 'This is example text file content'
 
       mockApi().get('/files/fileId')


### PR DESCRIPTION
A value for `0` for `maximumAge` forces a new location to be obtained from the device, which can take a number of seconds in some cases. 

In order to speed up action creation, location data up to 5 minutes old should be an acceptable compromise.

- [x] Version 5.9.3