### PR TITLE
AUTH-1850: Override update() for Operator scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import * as evrythng from 'evrythng'
 Or use a simple script tag to load it from the CDN.
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.9.3/evrythng-5.9.3.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/5.10.0/evrythng-5.10.0.js"></script>
 ```
 
 Then use in a browser `script` tag using the `evrythng` global variable:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.9.3",
+  "version": "5.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "5.9.3",
+  "version": "5.10.0",
   "description": "Official Javascript SDK for the EVRYTHNG API.",
   "main": "./dist/evrythng.node.js",
   "scripts": {

--- a/src/scope/Operator.js
+++ b/src/scope/Operator.js
@@ -77,6 +77,22 @@ export default class Operator extends OperatorAccess(Scope) {
     return this.initPromise
   }
 
+  /**
+   * Update the self-same Operator's data.
+   *
+   * @param {object} data - Update payload, such as { customFields }
+   */
+  update (data) {
+    const opts = {
+      method: 'put',
+      url: `/operators/${this.id}`,
+      apiKey: this.apiKey,
+      data
+    }
+
+    return this._request(opts)
+  }
+
   // PRIVATE
 
   /**

--- a/test/e2e/index.spec.js
+++ b/test/e2e/index.spec.js
@@ -83,6 +83,10 @@ describe('evrythng.js', () => {
     require('./scope/actionApp.spec')()
   })
 
+  describe('as Operator', () => {
+    require('./scope/operator.spec')()
+  })
+
   describe('Misc', () => {
     require('./misc/alias.spec')()
     require('./misc/api.spec')('operator')

--- a/test/e2e/scope/operator.spec.js
+++ b/test/e2e/scope/operator.spec.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai')
+const { getScope, mockApi } = require('../util')
+
+module.exports = () => {
+  describe('Operator', () => {
+    let operator
+
+    before(() => {
+      operator = getScope('operator')
+    })
+
+    it('should allow self-same Operator update', async () => {
+      mockApi().put('/operators/operatorId')
+        .reply(200, {})
+      const res = await operator.update({
+        customFields: {
+          foo: 'bar'
+        }
+      })
+
+      expect(res).to.be.an('object')
+    })
+  })
+}

--- a/test/e2e/util.js
+++ b/test/e2e/util.js
@@ -21,6 +21,7 @@ const mockApi = (apiUrl = API_URL) => nock(apiUrl)
 const setup = async () => {
   mockApi().get('/access').reply(200, { actor: { id: 'operatorId' } })
   const operator = new Operator(OPERATOR_API_KEY)
+  await operator.init()
 
   const projectPayload = { name: 'Test Project' }
   mockApi().post('/projects', projectPayload)


### PR DESCRIPTION
Allows an Operator to update their own data (primarily customFields):

```js
const operator = new evrythng.Operator(OPERATOR_API_KEY);

await operator.update({
  customFields: {
    type: 'researcher',
  },
});
```

- [x] Add test
- [x] Version