### PR TITLE
AM-962: Fix reactorLog create request for TrustedApp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,5 +15,5 @@ jobs:
           name: 'Audit dependencies'
           command: 'npm audit'
       - run:
-          name: 'E2E tests'
+          name: 'Run tests'
           command: 'npm test'

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import * as evrythng from 'evrythng';
 Or use a simple script tag to load it from the CDN.
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.1/evrythng-6.0.1.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.2/evrythng-6.0.2.js"></script>
 ```
 
 Then use in a browser `script` tag using the `evrythng` global variable:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6165,9 +6165,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/https-browserify": {
@@ -7353,9 +7353,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash-es": {
@@ -16604,9 +16604,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "https-browserify": {
@@ -17533,9 +17533,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash-es": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evrythng",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evrythng",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Official Javascript SDK for the EVRYTHNG API.",
   "main": "./dist/evrythng.node.js",
   "scripts": {

--- a/src/entity/ReactorLog.js
+++ b/src/entity/ReactorLog.js
@@ -1,9 +1,5 @@
 import Entity from './Entity'
 import Resource from '../resource/Resource'
-import Scope from '../scope/Scope'
-import symbols from '../symbols'
-import isUndefined from 'lodash-es/isUndefined'
-import isFunction from 'lodash-es/isFunction'
 import isString from 'lodash-es/isString'
 
 const path = '/reactor/logs'
@@ -22,7 +18,8 @@ export default class ReactorLog extends Entity {
           throw new TypeError('There is no single resource for Reactor Logs')
         }
 
-        const appPath = this instanceof Scope ? this[symbols.path] : ''
+        // Find the path to this application
+        const appPath = `/projects/${this.project}/applications/${this.app}`
 
         return Object.assign(Resource.factoryFor(ReactorLog, appPath + path).call(this, id), {
           create (...args) {
@@ -37,19 +34,15 @@ export default class ReactorLog extends Entity {
 /**
  * Use bulk endpoint when creating array of logs.
  *
- * @param {Object} data - Log payload.
- * @param {Array} rest - Rest of arguments.
+ * @param {Object} data - Logs payload.
+ * @param {Object} options - Optional request options.
  * @return {Promise}
  */
-function createLogs (data, ...rest) {
-  if (Array.isArray(data)) {
-    let [options] = rest
-    if (isUndefined(options) || isFunction(options)) {
-      options = {}
-      rest.unshift(options)
-    }
-    options.url = `${this.path}/bulk`
-  }
+function createLogs (data, options = {}) {
+  const logs = Array.isArray(data) ? data : [data]
 
-  return Resource.prototype.create.call(this, data, ...rest)
+  // Change URL for bulk creation
+  options.url = `${this.path}/bulk`
+
+  return Resource.prototype.create.call(this, logs, options)
 }

--- a/src/resource/Resource.js
+++ b/src/resource/Resource.js
@@ -252,7 +252,7 @@ export default class Resource {
       throw new TypeError('Create method must have payload.')
     }
     const req = {
-      url: this.path,
+      url: options && options.url ? options.url : this.path,
       data,
       method: 'post'
     }

--- a/src/scope/Scope.js
+++ b/src/scope/Scope.js
@@ -12,9 +12,9 @@ export default class Scope {
    * Creates an instance of Scope.
    *
    * @param {string} apiKey API Key of scope
-   * @param {Object} [body={}] Optional scope data
+   * @param {Object} [data={}] Optional scope data
    */
-  constructor (apiKey, body = {}) {
+  constructor (apiKey, data = {}) {
     if (!isString(apiKey)) {
       throw new Error('Scope constructor should be called with an API Key')
     }
@@ -22,7 +22,7 @@ export default class Scope {
     this.apiKey = apiKey
 
     // Extend scope with any given details.
-    Object.assign(this, body)
+    Object.assign(this, data)
   }
 
   /**

--- a/src/scope/TrustedApplication.js
+++ b/src/scope/TrustedApplication.js
@@ -8,6 +8,7 @@ import ReactorSchedule from '../entity/ReactorSchedule'
 import ReactorLog from '../entity/ReactorLog'
 import { mixinResources } from '../util/mixin'
 import api from '../api'
+import symbols from '../symbols'
 import isPlainObject from 'lodash-es/isPlainObject'
 
 /**
@@ -55,8 +56,15 @@ export default class TrustedApplication extends ApplicationAccess(Application) {
   constructor (apiKey, data = {}) {
     super(apiKey, data)
 
-    // Operation is the same as for Application scope.
-    this.initPromise = super.init()
+    this.initPromise = super
+      .readAccess()
+      .then((access) => {
+        this.id = access.actor.id
+        this.project = access.project
+        this.app = access.actor.id
+        this[symbols.path] = this._getPath()
+      })
+      .then(() => this.read())
   }
 
   /**

--- a/test/integration/entity/reactor.spec.js
+++ b/test/integration/entity/reactor.spec.js
@@ -139,7 +139,6 @@ const describeReactorLogsTests = () => {
     const res = await scope.reactorLog().create(payload)
 
     expect(res).to.be.an('array')
-    expect(res.cron).to.equal([])
   })
 }
 

--- a/test/integration/entity/reactor.spec.js
+++ b/test/integration/entity/reactor.spec.js
@@ -3,7 +3,7 @@ const { getScope, mockApi } = require('../util')
 
 const SCRIPT = 'function onActionCreated(event) { done(); }'
 
-let operator, api
+let scope, api
 
 const describeReactorScriptTests = () => {
   it('should update the Reactor script', async () => {
@@ -11,7 +11,7 @@ const describeReactorScriptTests = () => {
     api
       .put('/projects/projectId/applications/applicationId/reactor/script', payload)
       .reply(200, payload)
-    const res = await operator
+    const res = await scope
       .project('projectId')
       .application('applicationId')
       .reactorScript()
@@ -24,7 +24,7 @@ const describeReactorScriptTests = () => {
     api
       .get('/projects/projectId/applications/applicationId/reactor/script/status')
       .reply(200, { updating: false })
-    const res = await operator
+    const res = await scope
       .project('projectId')
       .application('applicationId')
       .reactorScript()
@@ -38,7 +38,7 @@ const describeReactorScriptTests = () => {
     api
       .get('/projects/projectId/applications/applicationId/reactor/script')
       .reply(200, { type: 'simple' })
-    const res = await operator
+    const res = await scope
       .project('projectId')
       .application('applicationId')
       .reactorScript()
@@ -59,7 +59,7 @@ const describeReactorScheduleTests = () => {
     api
       .post('/projects/projectId/applications/applicationId/reactor/schedules', payload)
       .reply(201, payload)
-    const res = await operator
+    const res = await scope
       .project('projectId')
       .application('applicationId')
       .reactorSchedule()
@@ -73,7 +73,7 @@ const describeReactorScheduleTests = () => {
     api
       .get('/projects/projectId/applications/applicationId/reactor/schedules')
       .reply(200, [{ id: 'scheduleId' }])
-    const res = await operator
+    const res = await scope
       .project('projectId')
       .application('applicationId')
       .reactorSchedule()
@@ -86,7 +86,7 @@ const describeReactorScheduleTests = () => {
     api
       .get('/projects/projectId/applications/applicationId/reactor/schedules/scheduleId')
       .reply(200, { id: 'scheduleId' })
-    const res = await operator
+    const res = await scope
       .project('projectId')
       .application('applicationId')
       .reactorSchedule('scheduleId')
@@ -100,7 +100,7 @@ const describeReactorScheduleTests = () => {
     api
       .put('/projects/projectId/applications/applicationId/reactor/schedules/scheduleId', payload)
       .reply(200, { id: 'scheduleId', enabled: false })
-    const res = await operator
+    const res = await scope
       .project('projectId')
       .application('applicationId')
       .reactorSchedule('scheduleId')
@@ -115,7 +115,7 @@ const describeReactorScheduleTests = () => {
     api
       .delete('/projects/projectId/applications/applicationId/reactor/schedules/scheduleId')
       .reply(200)
-    const res = await operator
+    const res = await scope
       .project('projectId')
       .application('applicationId')
       .reactorSchedule('scheduleId')
@@ -125,14 +125,38 @@ const describeReactorScheduleTests = () => {
   })
 }
 
+const describeReactorLogsTests = () => {
+  it('should create new Reactor logs', async () => {
+    const payload = [
+      {
+        message: 'This is a test log message',
+        logLevel: 'info'
+      }
+    ]
+    api
+      .post('/projects/projectId/applications/applicationId/reactor/logs/bulk', payload)
+      .reply(201, [])
+    const res = await scope.reactorLog().create(payload)
+
+    expect(res).to.be.an('array')
+    expect(res.cron).to.equal([])
+  })
+}
+
 module.exports = (scopeType, url) => {
   describe('Reactor', () => {
     before(async () => {
-      operator = getScope(scopeType)
+      scope = getScope(scopeType)
       api = mockApi(url)
     })
 
-    describeReactorScriptTests()
-    describeReactorScheduleTests()
+    if (scopeType === 'operator') {
+      describeReactorScriptTests()
+      describeReactorScheduleTests()
+    }
+
+    if (scopeType === 'trustedApplication') {
+      describeReactorLogsTests()
+    }
   })
 }

--- a/test/integration/testsForApiVersion1.spec.js
+++ b/test/integration/testsForApiVersion1.spec.js
@@ -40,6 +40,7 @@ describe('evrythng.js for apiVersion = 1', function () {
     require('./entity/properties.spec')(scopeType, 'product', apiUrl)
     require('./entity/properties.spec')(scopeType, 'thng', apiUrl)
     require('./entity/purchaseOrders.spec')(scopeType, apiUrl)
+    require('./entity/reactor.spec')(scopeType, apiUrl)
     require('./entity/thngs.spec')(scopeType, apiUrl)
   })
 

--- a/test/integration/testsForApiVersion2.spec.js
+++ b/test/integration/testsForApiVersion2.spec.js
@@ -11,7 +11,6 @@ describe('evrythng.js for apiVersion = 2', function () {
   })
 
   describe(`as Operator for API v${apiVersion}`, () => {
-    console.log(settings)
     const scopeType = 'operator'
     require('./entity/accessPolicies.spec')(scopeType, settings)
     require('./entity/accessTokens.spec')(scopeType, settings)

--- a/test/integration/util.js
+++ b/test/integration/util.js
@@ -52,6 +52,13 @@ const setupForApiVersion1 = async (apiUrl) => {
       actor: { id: 'applicationId' },
       project: 'projectId'
     })
+  mockApi(apiUrl)
+    .get('/access')
+    .reply(200, {
+      actor: { id: 'applicationId' },
+      project: 'projectId'
+    })
+  mockApi(apiUrl).get('/applications/me').reply(200, { id: 'applicationId' })
   mockApi(apiUrl).get('/applications/me').reply(200, { id: 'applicationId' })
   const trustedApplication = new TrustedApplication('secretApiKey')
   await trustedApplication.init()

--- a/test/integration/util.js
+++ b/test/integration/util.js
@@ -3,7 +3,6 @@ const {
   Application,
   TrustedApplication,
   Device,
-  api,
   AccessToken
 } = require('../../dist/evrythng.node')
 const nock = require('nock')
@@ -38,39 +37,24 @@ const setupForApiVersion1 = async (apiUrl) => {
     lastName: 'User'
   })
   const operator = new Operator(OPERATOR_API_KEY)
+  await operator.init()
 
-  const projectPayload = { name: 'Test Project' }
-  mockApi(apiUrl)
-    .post('/projects', projectPayload)
-    .reply(201, { name: 'Test Project', id: 'projectId' })
-  const appProject = await operator.project().create(projectPayload)
-
-  const appPayload = { name: 'Test App', socialNetworks: {} }
-  mockApi(apiUrl).post('/projects/projectId/applications', appPayload).reply(201, {
-    name: 'Test App',
-    socialNetworks: {},
-    id: 'applicationId',
-    appApiKey: 'appApiKey'
-  })
-  const appResource = await operator.project(appProject.id).application().create(appPayload)
   mockApi(apiUrl)
     .get('/access')
     .reply(200, { actor: { id: 'applicationId' } })
   mockApi(apiUrl).get('/applications/me').reply(200, { id: 'applicationId' })
-  const application = new Application(appResource.appApiKey)
+  const application = new Application('appApiKey')
+  await application.init()
 
   mockApi(apiUrl)
-    .get('/projects/projectId/applications/applicationId/secretKey')
-    .reply(200, { secretApiKey: 'secretApiKey' })
-  const { secretApiKey } = await api({
-    url: '/projects/projectId/applications/applicationId/secretKey',
-    apiKey: operator.apiKey
-  })
-  mockApi(apiUrl)
     .get('/access')
-    .reply(200, { actor: { id: 'applicationId' } })
+    .reply(200, {
+      actor: { id: 'applicationId' },
+      project: 'projectId'
+    })
   mockApi(apiUrl).get('/applications/me').reply(200, { id: 'applicationId' })
-  const trustedApplication = new TrustedApplication(secretApiKey)
+  const trustedApplication = new TrustedApplication('secretApiKey')
+  await trustedApplication.init()
 
   mockApi(apiUrl)
     .post('/auth/evrythng/users?anonymous=true')
@@ -80,23 +64,14 @@ const setupForApiVersion1 = async (apiUrl) => {
     .reply(200, { actor: { id: 'evrythngUser' } })
   mockApi(apiUrl).get('/users/evrythngUser').reply(200, { id: 'evrythngUser' })
   const anonUser = await application.appUser().create({ anonymous: true })
+  await anonUser.init()
 
-  mockApi(apiUrl).post('/thngs').reply(201, { id: 'deviceThngId' })
-  const deviceThng = await operator.thng().create({ name: 'Test Device' })
-  mockApi(apiUrl)
-    .post('/auth/evrythng/thngs', { thngId: 'deviceThngId' })
-    .reply(201, { thngId: 'deviceThngId', thngApiKey: 'thngApiKey' })
-  const { thngApiKey } = await api({
-    url: '/auth/evrythng/thngs',
-    method: 'post',
-    apiKey: operator.apiKey,
-    data: { thngId: deviceThng.id }
-  })
   mockApi(apiUrl)
     .get('/access')
     .reply(200, { actor: { id: 'deviceThngId' } })
   mockApi(apiUrl).get('/thngs/deviceThngId').reply(200, { id: 'deviceThngId' })
-  const device = new Device(thngApiKey)
+  const device = new Device('thngApiKey')
+  await device.init()
 
   scopes = {
     operator,


### PR DESCRIPTION
Allowing the following that was broken, because the resource `path` was not set properly:
```js
const trustedApp = new evrythng.TrustedApplication(TRUSTED_APP_API_KEY);

const logs = [{
  message: 'This is a log message!',
  logLevel: 'info',
}];
await trustedApp.reactorLog().create(logs);
```

Chiefly used in Reactor wrapper.

- [x] Fix mysterious nock error
- [x] Version 6.0.2
