### PR TITLE
Add ReactorLog to Operator for use in Reactor for v2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import * as evrythng from 'evrythng';
 Or use a simple script tag to load it from the CDN.
 
 ```html
-<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.2/evrythng-6.0.2.js"></script>
+<script src="https://d10ka0m22z5ju5.cloudfront.net/js/evrythng/6.0.3/evrythng-6.0.3.js"></script>
 ```
 
 Then use in a browser `script` tag using the `evrythng` global variable:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evrythng",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evrythng",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evrythng",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Official Javascript SDK for the EVRYTHNG API.",
   "main": "./dist/evrythng.node.js",
   "scripts": {

--- a/src/entity/ReactorLog.js
+++ b/src/entity/ReactorLog.js
@@ -12,16 +12,25 @@ const path = '/reactor/logs'
 export default class ReactorLog extends Entity {
   static resourceFactory () {
     return {
-      reactorLog (id) {
-        // Reactor logs don't have single resource endpoint (e.g.: /logs/:id)
-        if (isString(arguments[0])) {
-          throw new TypeError('There is no single resource for Reactor Logs')
+      /**
+       * ReactorLog Entity resource. If using with Operator, app and project
+       * details are required.
+       *
+       * @param {string} appDetails - projectId and applicationId to use.proj
+       * @returns {Object}
+       */
+      reactorLog (projectId, applicationId) {
+        if (isString(projectId) && !isString(applicationId)) {
+          throw new Error('When using with Operator, projectId and applicationId are required')
         }
 
-        // Find the path to this application
-        const appPath = `/projects/${this.project}/applications/${this.app}`
+        const useProjectId = projectId || this.project
+        const useApplicationId = applicationId || this.app
 
-        return Object.assign(Resource.factoryFor(ReactorLog, appPath + path).call(this, id), {
+        // Find the path to this application
+        const appPath = `/projects/${useProjectId}/applications/${useApplicationId}`
+
+        return Object.assign(Resource.factoryFor(ReactorLog, appPath + path).call(this), {
           create (...args) {
             return createLogs.call(this, ...args)
           }

--- a/src/entity/ReactorLog.js
+++ b/src/entity/ReactorLog.js
@@ -16,7 +16,8 @@ export default class ReactorLog extends Entity {
        * ReactorLog Entity resource. If using with Operator, app and project
        * details are required.
        *
-       * @param {string} appDetails - projectId and applicationId to use.proj
+       * @param {string} projectId - Project ID, if using with Operator scope.
+       * @param {string} applicationId - Application ID, if using with Operator scope.
        * @returns {Object}
        */
       reactorLog (projectId, applicationId) {

--- a/src/scope/Operator.js
+++ b/src/scope/Operator.js
@@ -8,6 +8,7 @@ import Action from '../entity/Action'
 import ActionType from '../entity/ActionType'
 import Project from '../entity/Project'
 import PurchaseOrder from '../entity/PurchaseOrder'
+import ReactorLog from '../entity/ReactorLog'
 import Redirector from '../entity/Redirector'
 import Role from '../entity/Role'
 import Rule from '../entity/Rule'
@@ -42,6 +43,7 @@ const OperatorAccess = mixinResources([
   Product, // CRUDL
   Project, // CRUDL
   PurchaseOrder, // CRUDL
+  ReactorLog, // C
   Redirector, // RUD
   Role, // CRUD
   Rule,

--- a/test/integration/entity/reactor.spec.js
+++ b/test/integration/entity/reactor.spec.js
@@ -125,7 +125,7 @@ const describeReactorScheduleTests = () => {
   })
 }
 
-const describeReactorLogsTests = () => {
+const describeReactorLogsTests = (scopeType) => {
   it('should create new Reactor logs', async () => {
     const payload = [
       {
@@ -136,7 +136,13 @@ const describeReactorLogsTests = () => {
     api
       .post('/projects/projectId/applications/applicationId/reactor/logs/bulk', payload)
       .reply(201, [])
-    const res = await scope.reactorLog().create(payload)
+
+    let res
+    if (scopeType === 'operator') {
+      res = await scope.reactorLog('projectId', 'applicationId').create(payload)
+    } else {
+      res = await scope.reactorLog().create(payload)
+    }
 
     expect(res).to.be.an('array')
   })
@@ -152,6 +158,7 @@ module.exports = (scopeType, url) => {
     if (scopeType === 'operator') {
       describeReactorScriptTests()
       describeReactorScheduleTests()
+      describeReactorLogsTests(scopeType)
     }
 
     if (scopeType === 'trustedApplication') {


### PR DESCRIPTION
- [x] Version 6.0.3

For `apiVersion: 2` - allow Operator scope to create Reactor logs (for use in Reactor platform):

```js
const operator = new evrythng.Operator(OPERATOR_API_KEY);

const logs = [{ message: 'Test log message', logLevel: 'info' }];
await operator.reactorLog(projectId, applicationId).create(logs);
```

The previous way for `TrustedApplication` scope is still valid:

```js
evrythng.setup({ apiVersion: 1 });

const trustedApp = new evrythng.TrustedApplication(TRUSTED_APP_API_KEY);

trustedApp.reactorLog().create(logs);
```

I tried really hard to make the `ReactorLog` Resource factory class work with Scope and Entity parent classes (and associated automatic 'parent path' URL construction inherent from that), but it just wasn't happening.